### PR TITLE
Feature/evict

### DIFF
--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -19,6 +19,7 @@ OfflineDatabase::OfflineDatabase(std::string path_, uint64_t maximumCacheSize_)
     : path(std::move(path_)),
       maximumCacheSize(maximumCacheSize_) {
     ensureSchema();
+    insertedSinceEvictCheck = maximumCacheSize / 10 - (512 * 1024); // checks for evictions after caching 1/2 MB
 }
 
 OfflineDatabase::~OfflineDatabase() {
@@ -178,7 +179,7 @@ std::pair<bool, uint64_t> OfflineDatabase::putInternal(const Resource& resource,
         size = compressed ? compressedData.size() : response.data->size();
     }
 
-    if (evict_ && !evict(size)) {
+    if (evict_ && !checkEvict(size)) {
         Log::Debug(Event::Database, "Unable to make space for entry");
         return { false, 0 };
     }
@@ -591,7 +592,7 @@ void OfflineDatabase::deleteRegion(OfflineRegion&& region) {
     stmt->bind(1, region.getID());
     stmt->run();
 
-    evict(0);
+    evict();
     db->exec("PRAGMA incremental_vacuum");
 
     // Ensure that the cached offlineTileCount value is recalculated.
@@ -769,92 +770,116 @@ T OfflineDatabase::getPragma(const char * sql) {
     stmt->run();
     return stmt->get<T>(0);
 }
-
-// Remove least-recently used resources and tiles until the used database size,
-// as calculated by multiplying the number of in-use pages by the page size, is
-// less than the maximum cache size. Returns false if this condition cannot be
-// satisfied.
-//
-// SQLite database never shrinks in size unless we call VACCUM. We here
-// are monitoring the soft limit (i.e. number of free pages in the file)
-// and as it approaches to the hard limit (i.e. the actual file size) we
-// delete an arbitrary number of old cache entries. The free pages approach saves
-// us from calling VACCUM or keeping a running total, which can be costly.
-bool OfflineDatabase::evict(uint64_t neededFreeSize) {
-    uint64_t pageSize = getPragma<int64_t>("PRAGMA page_size");
-    uint64_t pageCount = getPragma<int64_t>("PRAGMA page_count");
-
-    auto usedSize = [&] {
-        return pageSize * (pageCount - getPragma<int64_t>("PRAGMA freelist_count"));
-    };
-
-    // The addition of pageSize is a fudge factor to account for non `data` column
-    // size, and because pages can get fragmented on the database.
-    while (usedSize() + neededFreeSize + pageSize > maximumCacheSize) {
-        // clang-format off
-        Statement accessedStmt = getStatement(
-            "SELECT max(accessed) "
-            "FROM ( "
-            "    SELECT accessed "
-            "    FROM resources "
-            "    LEFT JOIN region_resources "
-            "    ON resource_id = resources.id "
-            "    WHERE resource_id IS NULL "
-            "  UNION ALL "
-            "    SELECT accessed "
-            "    FROM tiles "
-            "    LEFT JOIN region_tiles "
-            "    ON tile_id = tiles.id "
-            "    WHERE tile_id IS NULL "
-            "  ORDER BY accessed ASC LIMIT ?1 "
-            ") "
-        );
-        accessedStmt->bind(1, 50);
-        // clang-format on
-        if (!accessedStmt->run()) {
-            return false;
-        }
-        Timestamp accessed = accessedStmt->get<Timestamp>(0);
-        
-        // clang-format off
-        Statement stmt1 = getStatement(
-            "DELETE FROM resources "
-            "WHERE id IN ( "
-            "  SELECT id FROM resources "
-            "  LEFT JOIN region_resources "
-            "  ON resource_id = resources.id "
-            "  WHERE resource_id IS NULL "
-            "  AND accessed <= ?1 "
-            ") ");
-        // clang-format on
-        stmt1->bind(1, accessed);
-        stmt1->run();
-        uint64_t changes1 = stmt1->changes();
-
-        // clang-format off
-        Statement stmt2 = getStatement(
-            "DELETE FROM tiles "
-            "WHERE id IN ( "
-            "  SELECT id FROM tiles "
-            "  LEFT JOIN region_tiles "
-            "  ON tile_id = tiles.id "
-            "  WHERE tile_id IS NULL "
-            "  AND accessed <= ?1 "
-            ") ");
-        // clang-format on
-        stmt2->bind(1, accessed);
-        stmt2->run();
-        uint64_t changes2 = stmt2->changes();
-
-        // The cached value of offlineTileCount does not need to be updated
-        // here because only non-offline tiles can be removed by eviction.
-
-        if (changes1 == 0 && changes2 == 0) {
-            return false;
-        }
+  
+// Remove least-recently used resources and tiles until the size of ambiently cached items
+// is less than the maximum cache size. This function keeps a running tally of the size
+// of recently inserted items in the database. Whenever 10% of the maximum cache size has
+// been added, it checks if an eviction is necessary.
+bool OfflineDatabase::checkEvict(uint64_t neededFreeSize) {
+    if (insertedSinceEvictCheck > maximumCacheSize / 10) {
+      insertedSinceEvictCheck = 0;
+      OfflineDatabase::evict();
     }
+    insertedSinceEvictCheck += neededFreeSize;
+    return neededFreeSize < maximumCacheSize;
+}
+  
+// Tallys the size of the ambiently cached tiles and resources in the database. If the size
+// is greater than the maximum cache size, it deletes 25% of the ambiently cached items.
+// This is run when offline map packs are deleted and regularly when using the map.
+// Returns true if the eviction process was run.
+bool OfflineDatabase::evict() {
+  // clang-format off
+  Statement tileSizeStmt = getStatement(
+                                           " SELECT "
+                                           " count(*), "
+                                           " SUM(length(data)) "
+                                           "  FROM tiles "
+                                           "  LEFT JOIN region_tiles "
+                                           "  ON tile_id = tiles.id "
+                                           "  WHERE tile_id IS NULL "
+                                        );
+  // clang-format on
+  if (!tileSizeStmt->run()) {
+    return false;
+  }
 
-    return true;
+  uint64_t tileCount = tileSizeStmt->get<int64_t>(0);
+  uint64_t tileCacheSize = tileSizeStmt->get<int64_t>(1);
+  
+  // clang-format off
+  Statement resourceSizeStmt = getStatement(
+                                        " SELECT "
+                                        " SUM(length(data)) "
+                                        "    FROM resources "
+                                        "    LEFT JOIN region_resources "
+                                        "    ON resource_id = resources.id "
+                                        "    WHERE resource_id IS NULL "
+                                        );
+  // clang-format on
+  if (!resourceSizeStmt->run()) {
+    return false;
+  }
+  
+  uint64_t resourceCacheSize = resourceSizeStmt->get<int64_t>(0);
+  float avgTileSize = tileCacheSize / tileCount;
+
+  if ((tileCacheSize + resourceCacheSize) < maximumCacheSize) {
+    return false;
+  }
+  
+  // Try to purge to approximately 75% of the maximum cache size
+  int64_t tilesToDelete = tileCount - (maximumCacheSize / avgTileSize) * 0.75;
+
+  // get accessed time to pivot deletes on
+  // clang-format off
+  Statement getPivotAccessedStmt = getStatement(
+                                            "SELECT accessed "
+                                            "  FROM tiles "
+                                            "  LEFT JOIN region_tiles "
+                                            "  ON tile_id = tiles.id "
+                                            "  WHERE tile_id IS NULL "
+                                            "ORDER BY accessed ASC "
+                                            "LIMIT 1 OFFSET ?1 "
+                                            );
+  // clang-format on
+  getPivotAccessedStmt->bind(1, tilesToDelete);
+  if (!getPivotAccessedStmt->run()) {
+    return false;
+  }
+
+  Timestamp accessed = getPivotAccessedStmt->get<Timestamp>(0);
+  
+  // clang-format off
+  Statement stmt1 = getStatement(
+                                 "DELETE FROM resources "
+                                 "WHERE id IN ( "
+                                 "  SELECT id FROM resources "
+                                 "  LEFT JOIN region_resources "
+                                 "  ON resource_id = resources.id "
+                                 "  WHERE resource_id IS NULL "
+                                 "  AND accessed <= ?1 "
+                                 ") ");
+  // clang-format on
+  stmt1->bind(1, accessed);
+  stmt1->run();
+  
+  // clang-format off
+  Statement stmt2 = getStatement(
+                                 "DELETE FROM tiles "
+                                 "WHERE id IN ( "
+                                 "  SELECT id FROM tiles "
+                                 "  LEFT JOIN region_tiles "
+                                 "  ON tile_id = tiles.id "
+                                 "  WHERE tile_id IS NULL "
+                                 "  AND accessed <= ?1 "
+                                 ") ");
+  // clang-format on
+  stmt2->bind(1, accessed);
+  stmt2->run();
+
+  insertedSinceEvictCheck = 0;
+  return true;
 }
 
 void OfflineDatabase::setOfflineMapboxTileCountLimit(uint64_t limit) {

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -108,11 +108,14 @@ private:
     T getPragma(const char *);
 
     uint64_t maximumCacheSize;
+    uint64_t insertedSinceEvictCheck;
 
     uint64_t offlineMapboxTileCountLimit = util::mapbox::DEFAULT_OFFLINE_TILE_COUNT_LIMIT;
     optional<uint64_t> offlineMapboxTileCount;
 
-    bool evict(uint64_t neededFreeSize);
+    bool checkEvict(uint64_t neededFreeSize);
+    bool evict();
+
 };
 
 } // namespace mbgl


### PR DESCRIPTION
New eviction policy. Keeps a running tally of the size of inserted tiles, and checks if it needs to purge every maxCacheSize/10

On an iPhone 5S, with a 500MB offline database, running the purge operation takes 0.2 seconds. Checking if it needs to purge the cache takes 1/10 that. 

Weirdly it seems slower on a the iphone 7, about 0.1 seconds to check and 0.3 to purge. Maybe the thread is more likely to be interrupted there?

Is it correct that it only needs to vacuum after an offline pack has been deleted?