### PR TITLE
[ios] make the maximum cache size settable

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -139,6 +139,11 @@ public:
      */
     void resume();
 
+    /*
+     * Sets the size of the ambient offline cache of tiles
+     */
+    void setMaximumCacheSize(uint64_t) const;
+
     // For testing only.
     void put(const Resource&, const Response&);
 

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -282,6 +282,11 @@ MGL_EXPORT
 - (void)setMaximumAllowedMapboxTiles:(uint64_t)maximumCount;
 
 /**
+ Sets the maximum size in bytes to be used for the ambient caching of tiles.
+ */
+- (void)setMaximumCacheSize:(uint64_t)cacheSize;
+
+/**
  The cumulative size, measured in bytes, of all downloaded resources on disk.
 
  The returned value includes all resources, including tiles, whether downloaded

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -375,6 +375,11 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = MGLOfflinePackUserInfoK
     _mbglFileSource->setOfflineMapboxTileCountLimit(maximumCount);
 }
 
+- (void)setMaximumCacheSize:(uint64_t)cacheSize {
+  _mbglFileSource->setMaximumCacheSize(cacheSize);
+}
+
+
 #pragma mark -
 
 - (unsigned long long)countOfBytesCompleted {

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -162,6 +162,10 @@ public:
         offlineDatabase.setOfflineMapboxTileCountLimit(limit);
     }
 
+    void setMaximumCacheSize(uint64_t cacheSize) {
+      offlineDatabase.setMaximumCacheSize(cacheSize);
+    }
+  
     void put(const Resource& resource, const Response& response) {
         offlineDatabase.put(resource, response);
     }
@@ -284,6 +288,10 @@ void DefaultFileSource::pause() {
 
 void DefaultFileSource::resume() {
     impl->resume();
+}
+  
+void DefaultFileSource::setMaximumCacheSize(uint64_t cacheSize) const {
+  impl->actor().invoke(&Impl::setMaximumCacheSize, cacheSize);
 }
 
 // For testing only:

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -892,5 +892,19 @@ uint64_t OfflineDatabase::getOfflineMapboxTileCount() {
     offlineMapboxTileCount = stmt->get<int64_t>(0);
     return *offlineMapboxTileCount;
 }
+  
+  void OfflineDatabase::setMaximumCacheSize(uint64_t cacheSize) {
+    bool runEviction = cacheSize < maximumCacheSize;
+    maximumCacheSize = cacheSize;
+    if (runEviction) {
+      evict(0);
+      db->exec("PRAGMA incremental_vacuum");
+    }
+  }
+  
+  uint64_t OfflineDatabase::getMaximumCacheSize() {
+    return maximumCacheSize;
+  }
+
 
 } // namespace mbgl

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -57,6 +57,9 @@ public:
     bool offlineMapboxTileCountLimitExceeded();
     uint64_t getOfflineMapboxTileCount();
 
+    void setMaximumCacheSize(uint64_t);
+    uint64_t getMaximumCacheSize();
+
 private:
     void connect(int flags);
     int userVersion();

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -140,7 +140,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a memory leak in MGLMapView. ([#7956](https://github.com/mapbox/mapbox-gl-native/pull/7956))
 * Fixed an issue that could prevent a cached style from appearing while the device is offline. ([#7770](https://github.com/mapbox/mapbox-gl-native/pull/7770))
 * Fixed an issue that could prevent a style from loading when reestablishing a network connection. ([#7902](https://github.com/mapbox/mapbox-gl-native/pull/7902))
-* `MGLOfflineStorage` instances now support a delegate conforming to `MGLOfflineStorageDelegate`, which allows altering URLs before they are requested from the Internet. ([#8084](https://github.com/mapbox/mapbox-gl-native/pull/8084))
+* `MGLOfflineStorage` instances now support a delegate conforming to `MGLOfflineStorageDelegate`, which allows altering URLs before they are requested from the internet. ([#8084](https://github.com/mapbox/mapbox-gl-native/pull/8084))
+* Added function to set the maximum cache size of `MGLOfflineStorage`
 
 ### Other changes
 


### PR DESCRIPTION
Adds functions to make the ambient cache size settable. 

I am also hoping to use this to clear the cache, by setting the cache size to 0 briefly. 

It would be nice if there is somewhere to store this value between runs, or load it when mapbox is initialized. If you are trying to use a larger than default cache size, and the eviction process runs before the cacheSize is set, some of the cache would be deleted.