### PR TITLE
Feature/priorityrunloop

### DIFF
--- a/platform/darwin/src/run_loop.cpp
+++ b/platform/darwin/src/run_loop.cpp
@@ -35,8 +35,15 @@ RunLoop::~RunLoop() {
     current().set(nullptr);
 }
 
+void RunLoop::push_front(std::shared_ptr<WorkTask> task) {
+  withMutex([&] {
+    priorityQueue.push(std::move(task)); });
+  impl->async->send();
+}
+  
 void RunLoop::push(std::shared_ptr<WorkTask> task) {
-    withMutex([&] { queue.push(std::move(task)); });
+    withMutex([&] {
+      queue.push(std::move(task)); });
     impl->async->send();
 }
 

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -211,7 +211,7 @@ std::unique_ptr<AsyncRequest> DefaultFileSource::request(const Resource& resourc
     public:
         DefaultFileRequest(Resource resource_, FileSource::Callback callback_, util::Thread<DefaultFileSource::Impl>& thread_)
             : thread(thread_),
-              workRequest(thread.invokeWithCallback(&DefaultFileSource::Impl::request, this, resource_, callback_)) {
+              workRequest(thread.priorityInvokeWithCallback(&DefaultFileSource::Impl::request, this, resource_, callback_)) {
         }
 
         ~DefaultFileRequest() override {

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -348,9 +348,15 @@ bool OfflineDatabase::putResource(const Resource& resource,
 }
   
 
-
 optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource::TileData& tile) {
     // clang-format off
+  
+  /*
+   
+   struct timespec start, finish;
+   double elapsed;
+   clock_gettime(CLOCK_MONOTONIC, &start);
+   
     Statement accessedStmt = getStatement(
         "UPDATE tiles "
         "SET accessed       = ?1 "
@@ -368,7 +374,13 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource:
     accessedStmt->bind(5, tile.y);
     accessedStmt->bind(6, tile.z);
     accessedStmt->run();
-
+   
+  clock_gettime(CLOCK_MONOTONIC, &finish);
+  elapsed = (finish.tv_sec - start.tv_sec)  -  (finish.tv_nsec - start.tv_nsec) / 1000000000.0;
+  if (elapsed > .001) {
+    Log::Info(Event::Database, "getTile set access time %f ms ", elapsed * 1000);
+  }
+   */
     // clang-format off
     Statement stmt = getStatement(
         //        0      1        2       3        4
@@ -408,6 +420,7 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource:
         response.data = std::make_shared<std::string>(*data);
         size = data->length();
     }
+
 
   return std::make_pair(response, size);
 }

--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -46,6 +46,12 @@ public:
         return loop->invokeWithCallback(bind(fn), std::forward<Args>(args)...);
     }
 
+    template <typename Fn, class... Args>
+    std::unique_ptr<AsyncRequest>
+    priorityInvokeWithCallback(Fn fn, Args&&... args) {
+      return loop->invokeWithCallback(bind(fn), std::forward<Args>(args)...);
+    }
+  
     // Invoke object->fn(args...) asynchronously, but wait for the result.
     template <typename Fn, class... Args>
     auto invokeSync(Fn fn, Args&&... args) {

--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -49,7 +49,7 @@ public:
     template <typename Fn, class... Args>
     std::unique_ptr<AsyncRequest>
     priorityInvokeWithCallback(Fn fn, Args&&... args) {
-      return loop->invokeWithCallback(bind(fn), std::forward<Args>(args)...);
+      return loop->priorityInvokeWithCallback(bind(fn), std::forward<Args>(args)...);
     }
   
     // Invoke object->fn(args...) asynchronously, but wait for the result.


### PR DESCRIPTION
Added a second queue to the DefaultFileSource runloop to put user waiting requests in. I changed it to a lifo/fifo list first, but then it was weird because all the high zoom tiles loaded before the low zoom.

Commented out setting tile access time for now, the getTile function otherwise takes ~200ms on the ipad mini 3, which is very noticeable when loading a screenful of tiles