### PR TITLE
do tile requests for immediate display on their own thread

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -141,8 +141,11 @@ public:
 
     class Impl;
 
-private:
     const std::unique_ptr<util::Thread<Impl>> thread;
+
+private:
+    const std::unique_ptr<util::Thread<Impl>> priorityThread;
+
     const std::unique_ptr<FileSource> assetFileSource;
     const std::unique_ptr<FileSource> localFileSource;
     std::string cachedBaseURL = mbgl::util::API_BASE_URL;

--- a/include/mbgl/util/work_task_impl.hpp
+++ b/include/mbgl/util/work_task_impl.hpp
@@ -33,7 +33,7 @@ public:
     // If the task has completed and the after callback has executed, this will
     // do nothing.
     void cancel() override {
-        std::lock_guard<std::recursive_mutex> lock(mutex);
+        //std::lock_guard<std::recursive_mutex> lock(mutex);
         *canceled = true;
     }
 

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -180,7 +180,7 @@ DefaultFileSource::DefaultFileSource(const std::string& cachePath,
                                      uint64_t maximumCacheSize)
     : thread(std::make_unique<util::Thread<Impl>>(util::ThreadContext{"DefaultFileSource", util::ThreadPriority::Low},
             cachePath, maximumCacheSize)),
-      priorityThread(std::make_unique<util::Thread<Impl>>(util::ThreadContext{"PriorityDefaultFileSource", util::ThreadPriority::Low}, cachePath, maximumCacheSize)),
+      priorityThread(std::make_unique<util::Thread<Impl>>(util::ThreadContext{"PriorityDefaultFileSource", util::ThreadPriority::Regular}, cachePath, maximumCacheSize)),
       assetFileSource(std::make_unique<AssetFileSource>(assetRoot)),
       localFileSource(std::make_unique<LocalFileSource>()) {
       

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -24,8 +24,12 @@ bool isAssetURL(const std::string& url) {
 
 namespace mbgl {
 
+DefaultFileSource * global_ptr = 0;
+
+
 class DefaultFileSource::Impl {
 public:
+
     Impl(const std::string& cachePath, uint64_t maximumCacheSize)
         : offlineDatabase(cachePath, maximumCacheSize) {
     }
@@ -130,8 +134,11 @@ public:
 
         if (resource.necessity == Resource::Required) {
             tasks[req] = onlineFileSource.request(revalidation, [=] (Response onlineResponse) {
-                this->offlineDatabase.put(revalidation, onlineResponse);
-                callback(onlineResponse);
+              // save the tile data to the database on the non priority thread
+              global_ptr->thread->invoke(&Impl::put, revalidation, onlineResponse);
+              //this->offlineDatabase.put(revalidation, onlineResponse);
+            
+              callback(onlineResponse);
             });
         }
     }
@@ -173,14 +180,21 @@ DefaultFileSource::DefaultFileSource(const std::string& cachePath,
                                      uint64_t maximumCacheSize)
     : thread(std::make_unique<util::Thread<Impl>>(util::ThreadContext{"DefaultFileSource", util::ThreadPriority::Low},
             cachePath, maximumCacheSize)),
+      priorityThread(std::make_unique<util::Thread<Impl>>(util::ThreadContext{"PriorityDefaultFileSource", util::ThreadPriority::Low}, cachePath, maximumCacheSize)),
       assetFileSource(std::make_unique<AssetFileSource>(assetRoot)),
       localFileSource(std::make_unique<LocalFileSource>()) {
+      
+      // make a global variable for this object so the priorityThread can find the regular thread to send work to.
+      // I couldn't figure out the syntax to just pass the regular thread to the priorityThread
+      global_ptr = this;
 }
 
 DefaultFileSource::~DefaultFileSource() = default;
 
 void DefaultFileSource::setAPIBaseURL(const std::string& baseURL) {
     thread->invoke(&Impl::setAPIBaseURL, baseURL);
+    priorityThread->invoke(&Impl::setAPIBaseURL, baseURL);
+
     cachedBaseURL = baseURL;
 }
 
@@ -190,6 +204,8 @@ std::string DefaultFileSource::getAPIBaseURL() const {
 
 void DefaultFileSource::setAccessToken(const std::string& accessToken) {
     thread->invoke(&Impl::setAccessToken, accessToken);
+    priorityThread->invoke(&Impl::setAccessToken, accessToken);
+
     cachedAccessToken = accessToken;
 }
 
@@ -204,6 +220,13 @@ void DefaultFileSource::setResourceTransform(std::function<std::string(Resource:
             callback(transform(kind, std::move(url)));
         }, kind_, std::move(url_), callback_);
     });
+  
+  // this sets the delegate for MGLOfflineStorage that changes the url
+  priorityThread->invoke(&Impl::setResourceTransform, [loop, transform](Resource::Kind kind_, std::string&& url_, auto callback_) {
+    return loop->invokeWithCallback([transform](Resource::Kind kind, std::string&& url, auto callback) {
+      callback(transform(kind, std::move(url)));
+    }, kind_, std::move(url_), callback_);
+  });
 }
 
 std::unique_ptr<AsyncRequest> DefaultFileSource::request(const Resource& resource, Callback callback) {
@@ -227,7 +250,7 @@ std::unique_ptr<AsyncRequest> DefaultFileSource::request(const Resource& resourc
     } else if (LocalFileSource::acceptsURL(resource.url)) {
         return localFileSource->request(resource, callback);
     } else {
-        return std::make_unique<DefaultFileRequest>(resource, callback, *thread);
+        return std::make_unique<DefaultFileRequest>(resource, callback, *priorityThread);
     }
 }
 
@@ -273,10 +296,12 @@ void DefaultFileSource::setMaximumCacheSize(uint64_t cacheSize) const {
 
 void DefaultFileSource::pause() {
     thread->pause();
+    priorityThread->pause();
 }
 
 void DefaultFileSource::resume() {
     thread->resume();
+    priorityThread->resume();
 }
 
 // For testing only:

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -347,7 +347,7 @@ bool OfflineDatabase::putResource(const Resource& resource,
 
 optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource::TileData& tile) {
     // clang-format off
-    Statement accessedStmt = getStatement(
+    /*Statement accessedStmt = getStatement(
         "UPDATE tiles "
         "SET accessed       = ?1 "
         "WHERE url_template = ?2 "
@@ -363,7 +363,7 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource:
     accessedStmt->bind(4, tile.x);
     accessedStmt->bind(5, tile.y);
     accessedStmt->bind(6, tile.z);
-    accessedStmt->run();
+    accessedStmt->run();*/
 
     // clang-format off
     Statement stmt = getStatement(

--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -90,6 +90,7 @@ const static bool sqliteVersionCheck __attribute__((unused)) = []() {
 
     // Enable SQLite logging before initializing the database.
     sqlite3_config(SQLITE_CONFIG_LOG, errorLogCallback, nullptr);
+    sqlite3_config(SQLITE_CONFIG_MULTITHREAD, errorLogCallback, nullptr);
 
     return true;
 }();


### PR DESCRIPTION
Makes a second priority thread for DefaultFileSource that only handles fetching tiles for immediately display. It calls the non-priority thread to save the tiles, which also forces eviction to happen on the non-priority thread. 

Obviously the global pointer is not ideal. 