### PR TITLE
consider NoContent tiles as loaded

### DIFF
--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -41,7 +41,7 @@ void RasterTile::setData(std::shared_ptr<const std::string> data,
 
 void RasterTile::onParsed(std::unique_ptr<Bucket> result) {
     bucket = std::move(result);
-    availableData = bucket ? DataAvailability::All : DataAvailability::None;
+    availableData = bucket ? DataAvailability::All : DataAvailability::Never;
     observer->onTileChanged(*this);
 }
 

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -78,7 +78,7 @@ public:
     }
 
     bool isComplete() const {
-        return availableData == DataAvailability::All;
+      return availableData == DataAvailability::All || availableData == DataAvailability::Never;
     }
 
     void dumpDebugLogs() const;
@@ -104,6 +104,9 @@ protected:
 
         // Tile is fully parsed, and all buckets are available if they exist.
         All,
+      
+        // Data is never coming
+        Never
     };
 
     DataAvailability availableData = DataAvailability::None;


### PR DESCRIPTION
to not block delegate callbacks on the map view