### PR TITLE
fix tiles not showing when offline

### DIFF
--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -151,6 +151,10 @@ private:
 }
 
 - (void)offlineRegionStatusDidChange:(mbgl::OfflineRegionStatus)status {
+    if (_state == MGLOfflinePackStateInvalid) {
+      return;
+    }
+  
     NSAssert(_state != MGLOfflinePackStateInvalid, @"Cannot change update progress of an invalid offline pack.");
 
     switch (status.downloadState) {
@@ -227,8 +231,10 @@ NSError *MGLErrorFromResponseError(mbgl::Response::Error error) {
 @end
 
 void MBGLOfflineRegionObserver::statusChanged(mbgl::OfflineRegionStatus status) {
+    MGLOfflinePack * strongPack = pack;
+
     dispatch_async(dispatch_get_main_queue(), ^{
-        [pack offlineRegionStatusDidChange:status];
+        [strongPack offlineRegionStatusDidChange:status];
     });
 }
 

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -83,8 +83,9 @@ public:
         @autoreleasepool {
             NSURLSessionConfiguration* sessionConfig =
                 [NSURLSessionConfiguration defaultSessionConfiguration];
-            sessionConfig.timeoutIntervalForResource = 30;
-            sessionConfig.HTTPMaximumConnectionsPerHost = 8;
+            //sessionConfig.timeoutIntervalForResource = 30;
+            sessionConfig.timeoutIntervalForRequest = 360;
+            sessionConfig.HTTPMaximumConnectionsPerHost = 30;
             sessionConfig.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
             sessionConfig.URLCache = nil;
 
@@ -193,7 +194,7 @@ HTTPFileSource::HTTPFileSource()
 HTTPFileSource::~HTTPFileSource() = default;
 
 uint32_t HTTPFileSource::maximumConcurrentRequests() {
-    return 20;
+    return 30;
 }
 
 std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, Callback callback) {

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -160,10 +160,16 @@ public:
                     revalidation.priorExpires = offlineResponse->expires;
                     revalidation.priorEtag = offlineResponse->etag;
                     callback(*offlineResponse);
-                }
 
+                }
             }
 
+            auto now = util::now();
+            
+            if (bool(revalidation.priorExpires) && *revalidation.priorExpires > now) {
+              return;
+            }
+          
             // Get from the online file source
             if (resource.necessity == Resource::Required) {
 

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -657,7 +657,7 @@ uint64_t OfflineDatabase::putRegionResource(int64_t regionID, const Resource& re
         rtile.z = resource.tileData->z;
         rtile.regionID = regionID;
         rtile.expires = response.expires.value_or(util::now() + Seconds(1209600));
-        rtile.etag = response.etag.value_or(nullptr);
+        rtile.etag = response.etag;
         rtile.modified = response.modified.value_or(util::now());
         rtile.noContent = response.noContent;
     

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -662,7 +662,7 @@ uint64_t OfflineDatabase::putRegionResource(int64_t regionID, const Resource& re
         rtile.noContent = response.noContent;
     
         pending_tiles.push_back(rtile);
-        if (pending_tiles.size() > 10) {
+        if (pending_tiles.size() > 100) {
             savePendingTiles();
         }
         return size;

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -634,7 +634,6 @@ optional<int64_t> OfflineDatabase::hasRegionResource(int64_t regionID, const Res
 }
 
 uint64_t OfflineDatabase::putRegionResource(int64_t regionID, const Resource& resource, const Response& response) {
-    return 0;
     uint64_t size = putInternal(resource, response, false).second;
     bool previouslyUnused = markUsed(regionID, resource);
 

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -120,6 +120,7 @@ private:
     bool checkEvict(uint64_t neededFreeSize);
     bool evict(uint64_t neededFreeSize);
     bool evict();
+    void vacuum();
   
     struct region_tile {
       Timestamp expires;

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -59,6 +59,7 @@ public:
 
     void setMaximumCacheSize(uint64_t);
     uint64_t getMaximumCacheSize();
+    void savePendingTiles();
 
 private:
     void connect(int flags);
@@ -119,6 +120,24 @@ private:
     bool checkEvict(uint64_t neededFreeSize);
     bool evict(uint64_t neededFreeSize);
     bool evict();
+  
+    struct region_tile {
+      Timestamp expires;
+      Timestamp modified;
+      std::string etag;
+      std::string data;
+      std::string urlTemplate;
+      uint8_t pixelRatio;
+      int32_t x;
+      int32_t y;
+      int8_t z;
+      int64_t regionID;
+      bool compressed;
+      bool noContent;
+    };
+  
+    std::vector<region_tile> pending_tiles;
+
 
 };
 

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -124,7 +124,7 @@ private:
     struct region_tile {
       Timestamp expires;
       Timestamp modified;
-      std::string etag;
+      optional<std::string> etag;
       std::string data;
       std::string urlTemplate;
       uint8_t pixelRatio;

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -336,7 +336,6 @@ void OfflineDownload::ensureResource(const Resource& resource,
 
             status.completedResourceCount++;
             uint64_t resourceSize = offlineDatabase.putRegionResource(id, resource, onlineResponse);
-            resourceSize = onlineResponse.data->size();
             status.completedResourceSize += resourceSize;
             if (resource.kind == Resource::Kind::Tile) {
                 status.completedTileCount += 1;

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -336,6 +336,7 @@ void OfflineDownload::ensureResource(const Resource& resource,
 
             status.completedResourceCount++;
             uint64_t resourceSize = offlineDatabase.putRegionResource(id, resource, onlineResponse);
+            resourceSize = onlineResponse.data->size();
             status.completedResourceSize += resourceSize;
             if (resource.kind == Resource::Kind::Tile) {
                 status.completedTileCount += 1;

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -270,6 +270,7 @@ void OfflineDownload::deactivateDownload() {
     requiredSourceURLs.clear();
     resourcesRemaining.clear();
     requests.clear();
+    offlineDatabase.savePendingTiles();
 }
 
 void OfflineDownload::queueResource(Resource resource) {

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -349,7 +349,7 @@ void OnlineFileRequest::completed(Response response) {
         failedRequestReason = Response::Error::Reason::Success;
     }
 
-    schedule(response.expires);
+    //schedule(response.expires);
 
     // Calling the callback may result in `this` being deleted. It needs to be done last,
     // and needs to make a local copy of the callback to ensure that it remains valid for

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -656,9 +656,14 @@ public:
     MGLAssertIsMainThread();
 
     MGLReachability *reachability = [notification object];
-    if ( ! _isWaitingForRedundantReachableNotification && [reachability isReachable])
+    if ( ! _isWaitingForRedundantReachableNotification)
     {
-        mbgl::NetworkStatus::Reachable();
+      if ([reachability isReachable]) {
+          mbgl::NetworkStatus::Set(mbgl::NetworkStatus::Status::Online);
+          mbgl::NetworkStatus::Reachable();
+      } else {
+          mbgl::NetworkStatus::Set(mbgl::NetworkStatus::Status::Offline);
+      }
     }
     _isWaitingForRedundantReachableNotification = NO;
 }

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -90,7 +90,9 @@ void TileLoader<T>::makeOptional() {
 template <typename T>
 void TileLoader<T>::loadedData(const Response& res) {
     if (res.error && res.error->reason != Response::Error::Reason::NotFound) {
-        tile.setError(std::make_exception_ptr(std::runtime_error(res.error->message)));
+        if (!(tile.isComplete() && tile.isRenderable())) {
+          tile.setError(std::make_exception_ptr(std::runtime_error(res.error->message)));
+        }
     } else if (res.notModified) {
         resource.priorExpires = res.expires;
         // Do not notify the tile; when we get this message, it already has the current


### PR DESCRIPTION
Mapbox was overzealously refetching tiles in case they might be expired. If we want to show tiles that expire every minute for some reason layer we might want to undo some of these changes.

Fixed offline behavior where it would fetch tiles when offline, and then remove the loaded tile because it errored.