### PR TITLE
this makes downloads in gaia gps 10x faster with gaia topo

### DIFF
--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -151,6 +151,10 @@ private:
 }
 
 - (void)offlineRegionStatusDidChange:(mbgl::OfflineRegionStatus)status {
+    if (_state == MGLOfflinePackStateInvalid) {
+      return;
+    }
+  
     NSAssert(_state != MGLOfflinePackStateInvalid, @"Cannot change update progress of an invalid offline pack.");
 
     switch (status.downloadState) {
@@ -227,8 +231,10 @@ NSError *MGLErrorFromResponseError(mbgl::Response::Error error) {
 @end
 
 void MBGLOfflineRegionObserver::statusChanged(mbgl::OfflineRegionStatus status) {
+    MGLOfflinePack * strongPack = pack;
+
     dispatch_async(dispatch_get_main_queue(), ^{
-        [pack offlineRegionStatusDidChange:status];
+        [strongPack offlineRegionStatusDidChange:status];
     });
 }
 

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -657,7 +657,7 @@ uint64_t OfflineDatabase::putRegionResource(int64_t regionID, const Resource& re
         rtile.z = resource.tileData->z;
         rtile.regionID = regionID;
         rtile.expires = response.expires.value_or(util::now() + Seconds(1209600));
-        rtile.etag = response.etag.value_or(nullptr);
+        rtile.etag = response.etag;
         rtile.modified = response.modified.value_or(util::now());
         rtile.noContent = response.noContent;
     

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -662,7 +662,7 @@ uint64_t OfflineDatabase::putRegionResource(int64_t regionID, const Resource& re
         rtile.noContent = response.noContent;
     
         pending_tiles.push_back(rtile);
-        if (pending_tiles.size() > 10) {
+        if (pending_tiles.size() > 100) {
             savePendingTiles();
         }
         return size;

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -120,6 +120,7 @@ private:
     bool checkEvict(uint64_t neededFreeSize);
     bool evict(uint64_t neededFreeSize);
     bool evict();
+    void vacuum();
   
     struct region_tile {
       Timestamp expires;

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -59,6 +59,7 @@ public:
 
     void setMaximumCacheSize(uint64_t);
     uint64_t getMaximumCacheSize();
+    void savePendingTiles();
 
 private:
     void connect(int flags);
@@ -119,6 +120,24 @@ private:
     bool checkEvict(uint64_t neededFreeSize);
     bool evict(uint64_t neededFreeSize);
     bool evict();
+  
+    struct region_tile {
+      Timestamp expires;
+      Timestamp modified;
+      std::string etag;
+      std::string data;
+      std::string urlTemplate;
+      uint8_t pixelRatio;
+      int32_t x;
+      int32_t y;
+      int8_t z;
+      int64_t regionID;
+      bool compressed;
+      bool noContent;
+    };
+  
+    std::vector<region_tile> pending_tiles;
+
 
 };
 

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -124,7 +124,7 @@ private:
     struct region_tile {
       Timestamp expires;
       Timestamp modified;
-      std::string etag;
+      optional<std::string> etag;
       std::string data;
       std::string urlTemplate;
       uint8_t pixelRatio;

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -270,6 +270,7 @@ void OfflineDownload::deactivateDownload() {
     requiredSourceURLs.clear();
     resourcesRemaining.clear();
     requests.clear();
+    offlineDatabase.savePendingTiles();
 }
 
 void OfflineDownload::queueResource(Resource resource) {


### PR DESCRIPTION
batches database inserts into groups of 10 when downloading tiles.

This lets my downloads run at about 10MB/s in Gaia GPS instead of ~1.5. 

