### PR TITLE
fix crash rendering some areas when changing map source

### DIFF
--- a/src/mbgl/renderer/painters/painter_fill.cpp
+++ b/src/mbgl/renderer/painters/painter_fill.cpp
@@ -19,6 +19,10 @@ void Painter::renderFill(PaintParameters& parameters,
                          const RenderTile& tile) {
     const FillPaintProperties::PossiblyEvaluated& properties = layer.evaluated;
 
+    if (!&layer) {
+      return;
+    }
+
     if (!properties.get<FillPattern>().from.empty()) {
         if (pass != RenderPass::Translucent) {
             return;

--- a/src/mbgl/renderer/painters/painter_line.cpp
+++ b/src/mbgl/renderer/painters/painter_line.cpp
@@ -20,6 +20,10 @@ void Painter::renderLine(PaintParameters& parameters,
     if (pass == RenderPass::Opaque) {
         return;
     }
+  
+    if (!&layer) {
+      return;
+    }
 
     const RenderLinePaintProperties::PossiblyEvaluated& properties = layer.evaluated;
 


### PR DESCRIPTION
Changing to a map source that used Gaia Topo (gaiatopo or satellite + labels) would crash in some areas without this change because layer was null. 

An area that crashes is Kidd Lake Group Campground. (search for kidd lake in app, click on group campground result)

The map seems to render fine returning here. 

The layer is NULL because it's called from here - https://github.com/trailbehind/mapbox-gl-native/blob/master/src/mbgl/renderer/buckets/line_bucket.cpp#L465 and casting it to RenderLineLayer fails. 