### PR TITLE
handle 403s the same as 404s

### DIFF
--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -289,7 +289,8 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
 
                     if (responseCode == 200) {
                         response.data = std::make_shared<std::string>((const char *)[data bytes], [data length]);
-                    } else if (responseCode == 204 || (responseCode == 404 && resource.kind == Resource::Kind::Tile)) {
+                    } else if (responseCode == 204 ||
+                               ((responseCode == 403 || responseCode == 404) && resource.kind == Resource::Kind::Tile)) {
                         response.noContent = true;
                     } else if (responseCode == 304) {
                         response.notModified = true;


### PR DESCRIPTION
Because tiles served on s3 return 403 when they mean 404.