### PR TITLE
handle 403s the same as 404s

### DIFF
--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -334,7 +334,8 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
 
                     if (responseCode == 200) {
                         response.data = std::make_shared<std::string>((const char *)[data bytes], [data length]);
-                    } else if (responseCode == 204 || (responseCode == 404 && isTile)) {
+                    } else if (responseCode == 204 || 
+                        ((responseCode == 403 || responseCode == 404) && isTile)) {
                         response.noContent = true;
                     } else if (responseCode == 304) {
                         response.notModified = true;


### PR DESCRIPTION
Because s3 returns 403 when it means 404